### PR TITLE
Only append footer if buttons exist.

### DIFF
--- a/js/bootstrap-dialog.js
+++ b/js/bootstrap-dialog.js
@@ -111,7 +111,7 @@
             this.getModalContent()
             .append(this.getModalHeader())
             .append(this.getModalBody())
-            .append(this.getModalFooter());
+            .append(this.getButtons().length ? this.getModalFooter() : null);
 
             return this;
         },


### PR DESCRIPTION
When creating dialogs without any buttons specified, the footer is still appended to the modal body. I am not sure whether or not you want to enforce buttons being present, or implement this another way, but this solved the problem in my cases.

Thanks
