### PR TITLE
Update bootstrap-dialog.js

### DIFF
--- a/src/js/bootstrap-dialog.js
+++ b/src/js/bootstrap-dialog.js
@@ -88,7 +88,7 @@
 
     BootstrapDialog.ICON_SPINNER = 'glyphicon glyphicon-asterisk';
 
-    BootstrapDialog.ZINDEX_BACKDROP = 1040;
+    BootstrapDialog.ZINDEX_BACKDROP = 0;
     BootstrapDialog.ZINDEX_MODAL = 1050;
 
     /**


### PR DESCRIPTION
# for Issue "Backdrop overshadows dialog with Bootstrap 3.3"

just change:

``` js
BootstrapDialog.ZINDEX_BACKDROP = 1040; 
```

to

``` js
BootstrapDialog.ZINDEX_BACKDROP = 0; 
```
