### PR TITLE
fixed ORIGINAL_BODY_PADDING's value type bug

### DIFF
--- a/dist/js/bootstrap-dialog.js
+++ b/dist/js/bootstrap-dialog.js
@@ -56,7 +56,7 @@
 
         return version;
     };
-    BootstrapDialogModal.ORIGINAL_BODY_PADDING = $('body').css('padding-right') || 0;
+    BootstrapDialogModal.ORIGINAL_BODY_PADDING = parseInt(($('body').css('padding-right') || 0), 10);
     BootstrapDialogModal.METHODS_TO_OVERRIDE = {};
     BootstrapDialogModal.METHODS_TO_OVERRIDE['v3.1'] = {};
     BootstrapDialogModal.METHODS_TO_OVERRIDE['v3.2'] = {


### PR DESCRIPTION
BootstrapDialogModal.ORIGINAL_BODY_PADDING's value may be "0 px",so it's should add parseInt function