### PR TITLE
Button autospin should go before action

### DIFF
--- a/src/js/bootstrap-dialog.js
+++ b/src/js/bootstrap-dialog.js
@@ -849,12 +849,11 @@
                 var dialog = event.data.dialog;
                 var $button = event.data.$button;
                 var button = $button.data('button');
-                if (typeof button.action === 'function') {
-                    button.action.call($button, dialog, event);
-                }
-
                 if (button.autospin) {
                     $button.toggleSpin(true);
+                }
+                if (typeof button.action === 'function') {
+                    button.action.call($button, dialog, event);
                 }
             });
 


### PR DESCRIPTION
I was doing some check in a button action with autospin set to true and if a check fails I want to stop button spinning. In current code base this is not possible because autospin is triggered after user action. So there's no way (unless you use setTimeout) to stop autospinning in user action, e.g. the following won't work

```js
BootstrapDialog.show({
  message: 'I send ajax request!',
  buttons: [{
    icon: 'glyphicon glyphicon-send',
    label: 'Send ajax request',
    cssClass: 'btn-primary',
    autospin: true,
    action: function (dialogRef) {
      if (!somePrecondition()) {
        alert('Cannot proceed because of ...');
        this.stopSpin();
        return;
      }
      dialogRef.enableButtons(false);
      dialogRef.setClosable(false);
      dialogRef.getModalBody().html('Dialog closes in 5 seconds.');
      setTimeout(function () {
        dialogRef.close();
      }, 5000);
    }
  }]
});
```