### PR TITLE
Allow a mouseOver text for buttons

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -145,9 +145,11 @@
         BootstrapDialog.show({
             message: 'Hi Apple!',
             buttons: [{
-                label: 'Button 1'
+                label: 'Button 1',
+                mouseOver: 'Mouse over Button 1'
             }, {
                 label: 'Button 2',
+                // no mouseOver as it is optional
                 cssClass: 'btn-primary',
                 action: function(){
                     alert('Hi Orange!');
@@ -155,6 +157,7 @@
             }, {
                 icon: 'glyphicon glyphicon-ban-circle',
                 label: 'Button 3',
+                mouseOver: 'Mouse over Button 3',
                 cssClass: 'btn-warning'
             }, {
                 label: 'Close',

--- a/examples/index.html
+++ b/examples/index.html
@@ -6,7 +6,7 @@
 <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/js/bootstrap.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/prettify/r298/run_prettify.min.js"></script>
 <link href="https://cdnjs.cloudflare.com/ajax/libs/bootstrap3-dialog/1.34.9/css/bootstrap-dialog.min.css" rel="stylesheet" type="text/css" />
-<script src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap3-dialog/1.34.9/js/bootstrap-dialog.min.js"></script>
+<script src="../dist/js/bootstrap-dialog.min.js"></script>
 <meta charset="utf-8" />
 <title>BootstrapDialog examples</title>
 <style>
@@ -146,10 +146,10 @@
             message: 'Hi Apple!',
             buttons: [{
                 label: 'Button 1',
-                mouseOver: 'Mouse over Button 1'
+                title: 'Mouse over Button 1'
             }, {
                 label: 'Button 2',
-                // no mouseOver as it is optional
+                // no title as it is optional
                 cssClass: 'btn-primary',
                 action: function(){
                     alert('Hi Orange!');
@@ -157,7 +157,7 @@
             }, {
                 icon: 'glyphicon glyphicon-ban-circle',
                 label: 'Button 3',
-                mouseOver: 'Mouse over Button 3',
+                title: 'Mouse over Button 3',
                 cssClass: 'btn-warning'
             }, {
                 label: 'Close',

--- a/src/js/bootstrap-dialog.js
+++ b/src/js/bootstrap-dialog.js
@@ -836,6 +836,11 @@
                 $button.append(button.label);
             }
 
+            // mouseOver
+            if (typeof button.mouseOver !== 'undefined') {
+                $button.attr('title',  button.mouseOver);
+            }
+
             // Css class
             if (typeof button.cssClass !== 'undefined' && $.trim(button.cssClass) !== '') {
                 $button.addClass(button.cssClass);

--- a/src/js/bootstrap-dialog.js
+++ b/src/js/bootstrap-dialog.js
@@ -836,9 +836,9 @@
                 $button.append(button.label);
             }
 
-            // mouseOver
-            if (typeof button.mouseOver !== 'undefined') {
-                $button.attr('title',  button.mouseOver);
+            // title
+            if (typeof button.title !== 'undefined') {
+                $button.attr('title',  button.title);
             }
 
             // Css class


### PR DESCRIPTION
Hi,
thank you for your libary. I would like to add a mouseOver text to a button:

``` javascript
BootstrapDialog.show({
            message: 'Hi Apple!',
            buttons: [{
                label: 'Button 1',
                mouseOver: 'Mouse over Button 1'
            }, 
..
```
