### PR TITLE
Update bower.json with license information

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -18,6 +18,7 @@
         "dist/css/bootstrap-dialog.min.css",
         "dist/js/bootstrap-dialog.min.js"
     ],
+    "license": "MIT",
     "ignore": [
         "source",
         "spec",


### PR DESCRIPTION
Add the license to the bower.json file. This is needed by some tools (e.g. http://www.webjars.org/bower).