### PR TITLE
Add support for data attributes on buttons

### DIFF
--- a/src/js/bootstrap-dialog.js
+++ b/src/js/bootstrap-dialog.js
@@ -844,6 +844,13 @@
                 $button.addClass('btn-default');
             }
 
+            // Data attributes
+            if (typeof button.data === 'object' && button.data.constructor === {}.constructor) {
+                $.each(button.data, function (key, value) {
+                    $button.attr('data-'+key, value);
+                });
+            }
+
             // Hotkey
             if (typeof button.hotkey !== 'undefined') {
                 this.registeredButtonHotkeys[button.hotkey] = $button;


### PR DESCRIPTION
Regarding Issue #307, I have implemented the changes and it works great.

To reiterate, this is how it is implemented:

```
var sessionModal = new BootstrapDialog({
  title: 'Please provide details about the class',
  message: 'Hi there',
  buttons: [
  {
    id: 'delete-session-prompt-btn',
    label: 'Delete Class',
    cssClass: 'btn-danger pull-left hidden',
    data: {
      'js': 'delete-btn',
      'ui': 'something'
    }
  },
});
```

This results in `data-js="delete-btn"` and `data-ui="something"` on the button element.